### PR TITLE
Fix webpack version crash -- "Cannot read property 'entryOption' of undefined"

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "css-loader": "^1.0.1",
     "node-sass": "^4.10.0",
     "sass-loader": "^6.0.6",
-    "webpack-dev-server": "^3.0.0"
+    "webpack-dev-server": "3.0.0"
   },
   "scripts": {
     "start": "cross-env NODE_PATH=./src node scripts/start.js",


### PR DESCRIPTION
This change fixes the crash highlighted in several open issues, including #3, #4, and #5 